### PR TITLE
Update execution and stop endpoint.

### DIFF
--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -120,8 +120,8 @@ pub struct ProcessStatusResponse {
 
 #[derive(Serialize, Deserialize, ToSchema)]
 pub struct ExecuteRequest {
-    #[schema(example = "/path/to/executable")]
-    pub executable_path: String,
+    #[schema(example = "application-id-123")]
+    pub application_id: String,
 }
 // Add other models here
 


### PR DESCRIPTION
What Changed?:
     Execute program now takes in an application id, gets the path associated with that application from the DB, and executes it. We then store the PID of the process in a map with application id as the key. We also start a new thread that will monitor the process, although this will need more testing as we implement the status features.

     Stop process now finds all child processes related to a parent process (the parent process being the PID we get back from the execute endpoint). We kill all child processes first and then kill the parent process. Lastly, we update the process status and remove the process from the map (mentioned above).
     
Why was this needed?:
     After the implementation of the database, and the new program management endpoints, these old endpoints needed to be edited to use the application id of a program. This should also fix the issue of processes failing to stop. 