### PR TITLE
Delete category endpoint. Change swagger examples.

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -121,6 +121,7 @@ fn rocket() -> _ {
             crate::execution::get_application,
             crate::execution::get_all_applications,
             crate::execution::add_category,
+            crate::execution::delete_category,
         ),
         modifiers(&SecurityAddon),
     )]

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -133,10 +133,10 @@ pub struct ApplicationEntry {
     #[schema(example = "A simple calculator application.")]
     pub description: String,
 
-    #[schema(example = "user-id-1234")]
+    #[schema(example = "1")]
     pub user_id: String,
 
-    #[schema(example = "/path/to/executable")]
+    #[schema(example = "C:\\Windows\\System32\\notepad.exe")]
     pub executable_path: String,
 
     #[schema(example = "--arg1 --arg2")]
@@ -151,7 +151,7 @@ pub struct InstructionsEntry {
     #[schema(example = "instruction-id-1234")]
     pub id: String,
 
-    #[schema(example = "/path/to/executable")]
+    #[schema(example = "C:\\Windows\\System32\\notepad.exe")]
     pub path: String,
 
     #[schema(example = "--arg1 --arg2")]


### PR DESCRIPTION
What Changed?:
    Added an endpoint to delete categories (superadmin and admin only)
    Changed some of the swagger examples to be more clear on how to use endpoints that require a path.