### PR TITLE
Update application GETs to return category id AND name

### DIFF
--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -192,8 +192,11 @@ pub struct ApplicationDetails {
     pub name: String,
     pub description: String,
 
-    #[schema(example = json!(["category-id-5678", "category-id-9123"]))]
-    pub category_ids: Option<Vec<String>>, // Multiple category associations
+    #[schema(example = json!([
+        { "id": "category-id-5678", "name": "Utilities" },
+        { "id": "category-id-9123", "name": "Development" }
+    ]))]
+    pub categories: Vec<CategoryDetails>, // Now stores both category names & IDs
 }
 
 #[derive(Serialize, Deserialize, Clone, ToSchema)]

--- a/frontend/src/pages/Application.js
+++ b/frontend/src/pages/Application.js
@@ -7,45 +7,14 @@ function Application() {
   console.log("Application.js has loaded successfully!"); // Debug Log
 
   const [applications, setApplications] = useState([]);
-  const [categories, setCategories] = useState({});
   const [statusMessage, setStatusMessage] = useState("");
   const [searchTerm, setSearchTerm] = useState("");
 
   useEffect(() => {
-    fetchCategories();
     fetchApplications();
   }, []);
 
-  // Fetch categories and store them in a dictionary for easy lookup. TODO: There is probably a better way of handling this
-  const fetchCategories = async () => {
-    try {
-      let session_id = sessionStorage.getItem("session_id");
-      const response = await fetch("http://localhost:3000/api/categories", {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-          "x-session-id": session_id,
-        },
-      });
-
-      if (!response.ok) throw new Error("Failed to fetch categories");
-
-      const data = await response.json();
-      if (data.status === "success" && Array.isArray(data.categories)) {
-        const categoryMap = {};
-        data.categories.forEach((category) => {
-          categoryMap[category.id] = category.name;
-        });
-        setCategories(categoryMap);
-      } else {
-        throw new Error("Invalid categories data");
-      }
-    } catch (error) {
-      console.error("Error fetching categories:", error);
-    }
-  };
-
-  // Fetch applications
+  // Fetch applications (with category names included from the backend)
   const fetchApplications = async () => {
     try {
       let session_id = sessionStorage.getItem("session_id");
@@ -140,9 +109,9 @@ function Application() {
                 <tr key={app.application.id}>
                   <td>{app.application.name}</td>
                   <td>
-                    {app.application.category_ids
-                      ?.map((id) => categories[id] || id) // Replace UUID with name
-                      .join(", ") || "N/A"}
+                    {app.application.categories.length > 0
+                      ? app.application.categories.map((cat) => cat.name).join(", ")
+                      : "N/A"}
                   </td>
                   <td>{app.application.contact || "N/A"}</td>
                   <td>{app.application.description}</td>

--- a/frontend/src/pages/ViewApplication.js
+++ b/frontend/src/pages/ViewApplication.js
@@ -24,8 +24,8 @@ const ViewApplication = () => {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
-          "x-session-id": session_id
-        }
+          "x-session-id": session_id,
+        },
       });
 
       if (!response.ok) {
@@ -53,29 +53,29 @@ const ViewApplication = () => {
     setStatusMessage("Starting application...");
 
     try {
-        let session_id = sessionStorage.getItem("session_id");
-        if (!session_id) {
-            setStatusMessage("Session ID is missing. Please log in.");
-            return;
-        }
+      let session_id = sessionStorage.getItem("session_id");
+      if (!session_id) {
+        setStatusMessage("Session ID is missing. Please log in.");
+        return;
+      }
 
-        const response = await fetch(`http://localhost:3000/api/execute`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                "x-session-id": session_id
-            },
-            body: JSON.stringify({ application_id: application.id }) // Send application ID
-        });
+      const response = await fetch(`http://localhost:3000/api/execute`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-session-id": session_id,
+        },
+        body: JSON.stringify({ application_id: application.id }), // Send application ID
+      });
 
-        if (response.ok) {
-            setStatusMessage("Application started successfully.");
-        } else {
-            const errorData = await response.json();
-            setStatusMessage(`Failed to start application: ${errorData.message || "Unknown error"}`);
-        }
+      if (response.ok) {
+        setStatusMessage("Application started successfully.");
+      } else {
+        const errorData = await response.json();
+        setStatusMessage(`Failed to start application: ${errorData.message || "Unknown error"}`);
+      }
     } catch (error) {
-        setStatusMessage("Error: " + error.message);
+      setStatusMessage("Error: " + error.message);
     }
   };
 
@@ -86,7 +86,7 @@ const ViewApplication = () => {
       let session_id = sessionStorage.getItem("session_id");
       const response = await fetch(`http://localhost:3000/api/applications/remove/${id}`, {
         method: "DELETE",
-        headers: { "x-session-id": session_id }
+        headers: { "x-session-id": session_id },
       });
 
       if (response.ok) {
@@ -116,7 +116,11 @@ const ViewApplication = () => {
           </tr>
           <tr>
             <td><strong>Application Categories:</strong></td>
-            <td>{application.category_ids ? application.category_ids.join(", ") : "None"}</td>
+            <td>
+              {application.categories && application.categories.length > 0
+                ? application.categories.map((cat) => cat.name).join(", ")
+                : "None"}
+            </td>
           </tr>
           <tr>
             <td><strong>Executable Path:</strong></td>


### PR DESCRIPTION
What Changed?:
     get_all_applications and get_application now return the category name along with the category id. Related models for applications were also updated to reflect these changes. 

Why?:
     Before, on the applications page we only had access to the category ids after making a request to get_all_applications. We then had to store them in a dictionary to map id to name. This same issue was present in view application as well because get_application was only returning a category id. This change reduces the amount of calls we have to make to the backend, and cleans up the code for the frontend.