### PR TITLE
Fix spamming fetchRole in tutorial.ks

### DIFF
--- a/frontend/src/utils/tutorial.js
+++ b/frontend/src/utils/tutorial.js
@@ -10,8 +10,8 @@ export const useStartTutorial = () => {
   useEffect(() => {
     fetchRole().then((role) => {
       setUserRole(role);
-    })
-  })
+    });
+  }, []);
   const startTutorialManually = (currentPage) => {
     let steps = [];
 


### PR DESCRIPTION
If you don't add an empty dependency array to a use affect, it will run on every render.